### PR TITLE
Test CI works on different Python versions

### DIFF
--- a/citest/test/test_functionality.py
+++ b/citest/test/test_functionality.py
@@ -14,5 +14,11 @@ class TestFunctionality(unittest.TestCase):
         y = functionality.power4(x)
         self.assertEqual(y, 16)
 
+    def test_dict_union(self):
+        a = {'color': 'red', 'number': 2}
+        b = {'flavor': 'cherry'}
+        c = a | b
+        print(c)
+
 if __name__ == "__main__":
     unittest.main()

--- a/citest/test/test_functionality.py
+++ b/citest/test/test_functionality.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 
 from citest import functionality
 
@@ -17,7 +18,11 @@ class TestFunctionality(unittest.TestCase):
     def test_dict_union(self):
         a = {'color': 'red', 'number': 2}
         b = {'flavor': 'cherry'}
-        c = a | b
+        v = sys.version_info 
+        if v.major >= 3 and v.minor >= 9:
+            c = a | b
+        else:
+            c = {**a, **b}
         print(c)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Put in a statement that is only supported in Python >= 3.9
Check to make sure CI passes and fails in correct cases.